### PR TITLE
Add new slot status: CRYPT_SLOT_RESERVED

### DIFF
--- a/lib/libcryptsetup.h
+++ b/lib/libcryptsetup.h
@@ -1012,8 +1012,9 @@ typedef enum {
 	CRYPT_SLOT_INVALID, /**< invalid keyslot */
 	CRYPT_SLOT_INACTIVE, /**< keyslot is inactive (free) */
 	CRYPT_SLOT_ACTIVE, /**< keyslot is active (used) */
-	CRYPT_SLOT_ACTIVE_LAST /**< keylost is active (used)
-				*   and last used at the same time */
+	CRYPT_SLOT_ACTIVE_LAST, /**< keylost is active (used)
+				 *   and last used at the same time */
+	CRYPT_SLOT_RESERVED /**< keyslot is reserved (used) */
 } crypt_keyslot_info;
 
 /**
@@ -1027,6 +1028,16 @@ typedef enum {
  *
  */
 crypt_keyslot_info crypt_keyslot_status(struct crypt_device *cd, int keyslot);
+
+/**
+ * Reserve a key slot.
+ *
+ * @param cd crypt device handle
+ * @param keyslot requested keyslot or @e CRYPT_ANY_SLOT
+ *
+ * @return allocated key slot number or negative errno otherwise.
+ */
+int crypt_keyslot_reserve(struct crypt_device *cd, int keyslot);
 /** @} */
 
 /**

--- a/lib/luks1/keymanage.c
+++ b/lib/luks1/keymanage.c
@@ -142,6 +142,8 @@ static const char *dbg_slot_state(crypt_keyslot_info ki)
 		return "ACTIVE";
 	case CRYPT_SLOT_ACTIVE_LAST:
 		return "ACTIVE_LAST";
+	case CRYPT_SLOT_RESERVED:
+		return "RESERVED";
 	case CRYPT_SLOT_INVALID:
 	default:
 		return "INVALID";
@@ -355,6 +357,11 @@ static int _keyslot_repair(struct luks_phdr *phdr, struct crypt_device *ctx)
 	for(i = 0; i < LUKS_NUMKEYS; ++i) {
 		if (phdr->keyblock[i].active == LUKS_KEY_ENABLED)  {
 			log_dbg("Skipping repair for active keyslot %i.", i);
+			continue;
+		}
+
+		if (phdr->keyblock[i].active == LUKS_KEY_RESERVED)  {
+			log_dbg("Skipping repair for reserved keyslot %i.", i);
 			continue;
 		}
 
@@ -779,7 +786,7 @@ int LUKS_set_key(unsigned int keyIndex,
 	int r;
 
 	if(hdr->keyblock[keyIndex].active != LUKS_KEY_DISABLED) {
-		log_err(ctx, _("Key slot %d active, purge first.\n"), keyIndex);
+		log_err(ctx, _("Key slot %d not disabled, purge first.\n"), keyIndex);
 		return -EINVAL;
 	}
 
@@ -859,7 +866,7 @@ int LUKS_set_key(unsigned int keyIndex,
 		goto out;
 
 	/* Mark the key as active in phdr */
-	r = LUKS_keyslot_set(hdr, (int)keyIndex, 1);
+	r = LUKS_keyslot_set(hdr, (int)keyIndex, LUKS_KEY_ENABLED);
 	if (r < 0)
 		goto out;
 
@@ -909,7 +916,7 @@ static int LUKS_open_key(unsigned int keyIndex,
 	log_dbg("Trying to open key slot %d [%s].", keyIndex,
 		dbg_slot_state(ki));
 
-	if (ki < CRYPT_SLOT_ACTIVE)
+	if (ki != CRYPT_SLOT_ACTIVE && ki != CRYPT_SLOT_ACTIVE_LAST)
 		return -ENOENT;
 
 	derived_key = crypt_alloc_volume_key(hdr->keyBytes, NULL);
@@ -1003,7 +1010,7 @@ int LUKS_del_key(unsigned int keyIndex,
 	if (r)
 		return r;
 
-	r = LUKS_keyslot_set(hdr, keyIndex, 0);
+	r = LUKS_keyslot_set(hdr, keyIndex, LUKS_KEY_DISABLED);
 	if (r) {
 		log_err(ctx, _("Key slot %d is invalid, please select keyslot between 0 and %d.\n"),
 			keyIndex, LUKS_NUMKEYS - 1);
@@ -1037,6 +1044,26 @@ int LUKS_del_key(unsigned int keyIndex,
 	return r;
 }
 
+int LUKS_res_key(unsigned int keyIndex,
+		 struct luks_phdr *hdr,
+		 struct crypt_device *ctx)
+{
+	int r;
+
+	r = LUKS_read_phdr(hdr, 1, 0, ctx);
+	if (r)
+		return r;
+
+	r = LUKS_keyslot_set(hdr, keyIndex, LUKS_KEY_RESERVED);
+	if (r) {
+		log_err(ctx, _("Key slot %d is invalid, please select keyslot between 0 and %d.\n"),
+			keyIndex, LUKS_NUMKEYS - 1);
+		return r;
+	}
+
+	return LUKS_write_phdr(hdr, ctx);
+}
+
 crypt_keyslot_info LUKS_keyslot_info(struct luks_phdr *hdr, int keyslot)
 {
 	int i;
@@ -1046,6 +1073,9 @@ crypt_keyslot_info LUKS_keyslot_info(struct luks_phdr *hdr, int keyslot)
 
 	if (hdr->keyblock[keyslot].active == LUKS_KEY_DISABLED)
 		return CRYPT_SLOT_INACTIVE;
+
+	if (hdr->keyblock[keyslot].active == LUKS_KEY_RESERVED)
+		return CRYPT_SLOT_RESERVED;
 
 	if (hdr->keyblock[keyslot].active != LUKS_KEY_ENABLED)
 		return CRYPT_SLOT_INVALID;
@@ -1082,15 +1112,31 @@ int LUKS_keyslot_active_count(struct luks_phdr *hdr)
 	return num;
 }
 
-int LUKS_keyslot_set(struct luks_phdr *hdr, int keyslot, int enable)
+int LUKS_keyslot_set(struct luks_phdr *hdr, int keyslot, int mode)
 {
+	const char *modestr = NULL;
 	crypt_keyslot_info ki = LUKS_keyslot_info(hdr, keyslot);
 
 	if (ki == CRYPT_SLOT_INVALID)
 		return -EINVAL;
 
-	hdr->keyblock[keyslot].active = enable ? LUKS_KEY_ENABLED : LUKS_KEY_DISABLED;
-	log_dbg("Key slot %d was %s in LUKS header.", keyslot, enable ? "enabled" : "disabled");
+	switch (mode) {
+	case LUKS_KEY_ENABLED:
+		modestr = "enabled";
+		break;
+	case LUKS_KEY_DISABLED:
+		modestr = "disabled";
+		break;
+	case LUKS_KEY_RESERVED:
+		modestr = "reserved";
+		break;
+	default:
+		modestr = "unknown";
+		break;
+	}
+
+	hdr->keyblock[keyslot].active = mode;
+	log_dbg("Key slot %d was %s in LUKS header.", keyslot, modestr);
 	return 0;
 }
 

--- a/lib/luks1/luks.h
+++ b/lib/luks1/luks.h
@@ -44,6 +44,7 @@
 #define LUKS_KEY_ENABLED_OLD 0xCAFE
 
 #define LUKS_KEY_DISABLED 0x0000DEAD
+#define LUKS_KEY_RESERVED 0x00DDBA11
 #define LUKS_KEY_ENABLED  0x00AC71F3
 
 #define LUKS_STRIPES 4000
@@ -164,10 +165,15 @@ int LUKS_del_key(
 	struct luks_phdr *hdr,
 	struct crypt_device *ctx);
 
+int LUKS_res_key(
+	unsigned int keyIndex,
+	struct luks_phdr *hdr,
+	struct crypt_device *ctx);
+
 crypt_keyslot_info LUKS_keyslot_info(struct luks_phdr *hdr, int keyslot);
 int LUKS_keyslot_find_empty(struct luks_phdr *hdr);
 int LUKS_keyslot_active_count(struct luks_phdr *hdr);
-int LUKS_keyslot_set(struct luks_phdr *hdr, int keyslot, int enable);
+int LUKS_keyslot_set(struct luks_phdr *hdr, int keyslot, int mode);
 int LUKS_keyslot_area(const struct luks_phdr *hdr,
 	int keyslot,
 	uint64_t *offset,

--- a/lib/setup.c
+++ b/lib/setup.c
@@ -2229,7 +2229,8 @@ static int _luks_dump(struct crypt_device *cd)
 	log_std(cd, "MK iterations: \t%" PRIu32 "\n", cd->u.luks1.hdr.mkDigestIterations);
 	log_std(cd, "UUID:          \t%s\n\n", cd->u.luks1.hdr.uuid);
 	for(i = 0; i < LUKS_NUMKEYS; i++) {
-		if(cd->u.luks1.hdr.keyblock[i].active == LUKS_KEY_ENABLED) {
+		switch (cd->u.luks1.hdr.keyblock[i].active) {
+		case LUKS_KEY_ENABLED:
 			log_std(cd, "Key Slot %d: ENABLED\n",i);
 			log_std(cd, "\tIterations:         \t%" PRIu32 "\n",
 				cd->u.luks1.hdr.keyblock[i].passwordIterations);
@@ -2245,9 +2246,20 @@ static int _luks_dump(struct crypt_device *cd)
 				cd->u.luks1.hdr.keyblock[i].keyMaterialOffset);
 			log_std(cd, "\tAF stripes:            \t%" PRIu32 "\n",
 				cd->u.luks1.hdr.keyblock[i].stripes);
-		}
-		else 
+			break;
+
+		case LUKS_KEY_RESERVED:
+			log_std(cd, "Key Slot %d: RESERVED\n", i);
+			break;
+
+		case LUKS_KEY_DISABLED:
 			log_std(cd, "Key Slot %d: DISABLED\n", i);
+			break;
+
+		default:
+			log_std(cd, "Key Slot %d: UNKNOWN\n", i);
+			break;
+		}
 	}
 	return 0;
 }
@@ -2437,6 +2449,21 @@ crypt_keyslot_info crypt_keyslot_status(struct crypt_device *cd, int keyslot)
 		return CRYPT_SLOT_INVALID;
 
 	return LUKS_keyslot_info(&cd->u.luks1.hdr, keyslot);
+}
+
+int crypt_keyslot_reserve(struct crypt_device *cd, int keyslot)
+{
+	int r = 0;
+
+	r = onlyLUKS(cd);
+	if (r < 0)
+		return r;
+
+	r = keyslot_verify_or_find_empty(cd, &keyslot);
+	if (r)
+		return r;
+
+	return LUKS_res_key(keyslot, &cd->u.luks1.hdr, cd);
 }
 
 int crypt_keyslot_max(const char *type)

--- a/misc/keyslot_checker/chk_luks_keyslots.c
+++ b/misc/keyslot_checker/chk_luks_keyslots.c
@@ -171,18 +171,24 @@ static int check_keyslots(FILE *out, struct crypt_device *cd, int f_luks)
 	double ent;
 	off_t ofs;
 	uint64_t start, length, end;
-	crypt_keyslot_info ki;
 	unsigned char buffer[sector_size];
 
 	for (i = 0; i < crypt_keyslot_max(CRYPT_LUKS1) ; i++) {
 		fprintf(out, "- processing keyslot %d:", i);
-		ki = crypt_keyslot_status(cd, i);
-		if (ki == CRYPT_SLOT_INACTIVE) {
+		switch (crypt_keyslot_status(cd, i)) {
+		case CRYPT_SLOT_INACTIVE:
 			fprintf(out, "  keyslot not in use\n");
 			continue;
-		}
 
-		if (ki == CRYPT_SLOT_INVALID) {
+		case CRYPT_SLOT_RESERVED:
+			fprintf(out, "  keyslot reserved\n");
+			continue;
+
+		case CRYPT_SLOT_ACTIVE:
+		case CRYPT_SLOT_ACTIVE_LAST:
+			break;
+
+		default:
 			fprintf(out, "\nError: keyslot invalid.\n");
 			return EXIT_FAILURE;
 		}

--- a/python/pycryptsetup.c
+++ b/python/pycryptsetup.c
@@ -498,6 +498,7 @@ static PyObject *CryptSetup_killSlot(CryptSetupObject* self, PyObject *args, PyO
 
 	switch (crypt_keyslot_status(self->device, slot)) {
 	case CRYPT_SLOT_ACTIVE:
+	case CRYPT_SLOT_RESERVED:
 		return PyObjectResult(crypt_keyslot_destroy(self->device, slot));
 	case CRYPT_SLOT_ACTIVE_LAST:
 		PyErr_SetString(PyExc_ValueError, "Last slot, removing it would render the device unusable");

--- a/src/cryptsetup.c
+++ b/src/cryptsetup.c
@@ -881,6 +881,7 @@ static int action_luksKillSlot(void)
 		goto out;
 
 	switch (crypt_keyslot_status(cd, opt_key_slot)) {
+	case CRYPT_SLOT_RESERVED:
 	case CRYPT_SLOT_ACTIVE_LAST:
 	case CRYPT_SLOT_ACTIVE:
 		log_verbose(_("Key slot %d selected for deletion.\n"), opt_key_slot);
@@ -1326,7 +1327,6 @@ args:
 static int action_luksErase(void)
 {
 	struct crypt_device *cd = NULL;
-	crypt_keyslot_info ki;
 	char *msg = NULL;
 	int i, r;
 
@@ -1351,11 +1351,16 @@ static int action_luksErase(void)
 	}
 
 	for (i = 0; i < crypt_keyslot_max(CRYPT_LUKS1); i++) {
-		ki = crypt_keyslot_status(cd, i);
-		if (ki == CRYPT_SLOT_ACTIVE || ki == CRYPT_SLOT_ACTIVE_LAST) {
+		switch (crypt_keyslot_status(cd, i)) {
+		case CRYPT_SLOT_INACTIVE:
+		case CRYPT_SLOT_INVALID:
+			continue;
+
+		default:
 			r = crypt_keyslot_destroy(cd, i);
 			if (r < 0)
 				goto out;
+			break;
 		}
 	}
 out:


### PR DESCRIPTION
The status CRYPT_SLOT_RESERVED indicates that data is present in
a slot, but the slot is not a key. Hence, unlocking LUKS won't
attempt to use a key from this slot. Further, specifying
CRYPT_ANY_SLOT won't automatically allocate a reserved slot.