### PR TITLE
Add pbkdf options to all key operations in manpage

### DIFF
--- a/man/cryptsetup.8
+++ b/man/cryptsetup.8
@@ -318,7 +318,8 @@ is not required.
 \fB<options>\fR can be [\-\-key\-file, \-\-keyfile\-offset,
 \-\-keyfile\-size, \-\-new\-keyfile\-offset,
 \-\-new\-keyfile\-size, \-\-key\-slot, \-\-master\-key\-file,
-\-\-iter\-time, \-\-force\-password, \-\-header, \-\-disable\-locks,
+\-\-force\-password, \-\-header, \-\-disable\-locks,
+\-\-iter-time, \-\-pbkdf, \-\-pbkdf\-force\-iterations,
 \-\-unbound, \-\-type, \-\-keyslot\-cipher, \-\-keyslot\-key\-size].
 .PP
 \fIluksRemoveKey\fR <device> [<key file with passphrase to be removed>]
@@ -361,6 +362,7 @@ inaccessible.
 
 \fB<options>\fR can be [\-\-key\-file, \-\-keyfile\-offset,
 \-\-keyfile\-size, \-\-new\-keyfile\-offset,
+\-\-iter-time, \-\-pbkdf, \-\-pbkdf\-force\-iterations,
 \-\-new\-keyfile\-size, \-\-key\-slot, \-\-force\-password, \-\-header,
 \-\-disable\-locks, \-\-type, \-\-keyslot\-cipher, \-\-keyslot\-key\-size].
 .PP


### PR DESCRIPTION
Added some missing possible options to operations regarding key slots. May be other options missing too, I guess.